### PR TITLE
Build also against PHP 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ ubuntu-latest ]
-                php-versions: [ '7.4' ]
+                php-versions: [ '7.4', '8.0' ]
                 composer-dependencies: [ '', '--prefer-lowest' ]
                 composer-version: [ 'v1' ]
                 symfony-version: [ '' ]
@@ -33,6 +33,10 @@ jobs:
 
                     # Windows
                     -   php-versions: '7.4'
+                        operating-system: windows-latest
+
+                    # Windows
+                    -   php-versions: '8.0'
                         operating-system: windows-latest
 
         steps:


### PR DESCRIPTION
`eMAGTechLabs/RabbitMqBundle` is not yet compatible with PHP 8.0, so the build is failing until  https://github.com/eMAGTechLabs/RabbitMqBundle/issues/40 is resolved